### PR TITLE
Issue 8: Fixing show list videos not playing.

### DIFF
--- a/geekandsundry.py
+++ b/geekandsundry.py
@@ -236,11 +236,11 @@ def showVideoURL(url):
 
         # Get all the script and iframe tags in this wrapper and check for the one which has the brightcove player script
         scripts = vidDiv.find_all(['script', 'iframe'])
-        checkForBrightcovePlayer = lambda script: script.get("src") and script.get("src").startswith("//players.brightcove.net")
+        checkForBrightcovePlayer = lambda script: script.get("src") and script.get("src").startswith("https://players.brightcove.net")
         vidScript = filter(checkForBrightcovePlayer, scripts)[0]
 
         if vidScript and vidScript.get('src'):
-            src = 'http:' + vidScript.get('src')
+            src = vidScript.get('src')
 
             if vidScript.name == 'iframe':
                 ID = re.search("videoId=([^&']+)", src).group(1)


### PR DESCRIPTION
This fixes #8 and allows videos to be played when accessed by the show list. The recent list works fine because it gets the videos from youtube. While the show list gets the videos from http://geekandsundry.com/shows/ where they started using https.